### PR TITLE
Bugfix/fix profile edit #9

### DIFF
--- a/api/.gitignore
+++ b/api/.gitignore
@@ -46,3 +46,6 @@ out/
 ### TEMP ###
 /temp/
 /tmp/
+
+### Profile Image Directory ###
+img/

--- a/api/crewsync/src/main/java/com/example/crewsync/controllers/ProfileController.java
+++ b/api/crewsync/src/main/java/com/example/crewsync/controllers/ProfileController.java
@@ -11,12 +11,15 @@ import org.springframework.web.bind.annotation.PostMapping;
 
 import com.example.crewsync.common.utils.constants.RouteConstants;
 import com.example.crewsync.controllers.forms.ProfileEditForm;
+import com.example.crewsync.domains.models.ImageFile;
 import com.example.crewsync.domains.services.ProfileEditService;
 import com.example.crewsync.security.LoginUser;
 import com.example.crewsync.security.LoginUserDetails;
 
 import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Controller
 public class ProfileController {
 
@@ -62,10 +65,15 @@ public class ProfileController {
         }
         try {
             profileEditService.editProfile(profileEditForm);
+            model.addAttribute("success", "処理が正常に完了しました");
         } catch (Exception e) {
-            // 後々実装するかも
+            log.error("プロフィールの更新に失敗しました: {}", e.getMessage());
+            // サムネイルの再表示のため再度プロフィール画像をセットする
+            ImageFile imageFile = profileEditService.getProfileImg(user.getId());
+            user.setImageFile(imageFile);
+            model.addAttribute("loginUser", user);
+            model.addAttribute("failure", "処理に失敗しました。再度実行してください");
         }
-        model.addAttribute("notice", "処理が正常に完了しました");
         return RouteConstants.PROFILE;
     }
 }

--- a/api/crewsync/src/main/java/com/example/crewsync/domains/mappers/ProfileEditMapper.java
+++ b/api/crewsync/src/main/java/com/example/crewsync/domains/mappers/ProfileEditMapper.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import org.apache.ibatis.annotations.Mapper;
 
 import com.example.crewsync.controllers.forms.ProfileEditForm;
+import com.example.crewsync.domains.models.ImageFile;
 import com.example.crewsync.security.LoginUser;
 
 /**
@@ -27,4 +28,9 @@ public interface ProfileEditMapper {
      * ユーザーの個人情報を更新します
      */
     public int updatePersonalInfo(ProfileEditForm profileEditForm);
+
+    /**
+     * ユーザーIDからプロフィール画像を取得します
+     */
+    public ImageFile getImageFileById(long id);
 }

--- a/api/crewsync/src/main/java/com/example/crewsync/domains/models/ImageFile.java
+++ b/api/crewsync/src/main/java/com/example/crewsync/domains/models/ImageFile.java
@@ -6,11 +6,13 @@ import java.nio.file.Files;
 import java.util.Base64;
 
 import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * プロフィール編集画面の画像ファイルを保持するモデルクラスです
  */
 @Data
+@Slf4j
 public class ImageFile {
 
     private String fileName;
@@ -32,9 +34,10 @@ public class ImageFile {
             byte[] fileData = Files.readAllBytes(imageFile.toPath());
             base64String.append("data:");
             base64String.append(contentType);
-            base64String.append(":base64,");
+            base64String.append(";base64,");
             base64String.append(Base64.getEncoder().encodeToString(fileData));
         } catch (IOException e) {
+            log.warn("ファイルのエンコードに失敗しました: {}", e.getMessage());
             return "";
         }
         return base64String.toString();

--- a/api/crewsync/src/main/resources/com/example/crewsync/domains/mappers/ProfileEditMapper.xml
+++ b/api/crewsync/src/main/resources/com/example/crewsync/domains/mappers/ProfileEditMapper.xml
@@ -46,7 +46,7 @@
         telno = #{phoneNo},
         mobile_no = #{mobilePhoneNo}
       WHERE
-        user_id = #{id}
+        user_id = #{userId}
     ]]>
   </update>
   <!-- ユーザーのプロフィール画像を取得します-->

--- a/api/crewsync/src/main/resources/com/example/crewsync/domains/mappers/ProfileEditMapper.xml
+++ b/api/crewsync/src/main/resources/com/example/crewsync/domains/mappers/ProfileEditMapper.xml
@@ -49,4 +49,15 @@
         user_id = #{id}
     ]]>
   </update>
+  <!-- ユーザーのプロフィール画像を取得します-->
+  <select id="getImageFileById" parameterType="java.lang.Long" resultType="com.example.crewsync.domains.models.ImageFile">
+    <![CDATA[
+      SELECT
+        profile_img AS fileName
+      FROM
+        users
+      WHERE
+        id = #{userId}
+    ]]>
+  </select>
 </mapper>

--- a/api/crewsync/src/main/resources/templates/profile.html
+++ b/api/crewsync/src/main/resources/templates/profile.html
@@ -213,7 +213,7 @@
       id="toast"
       class="position-absolute bg-white shadow-lg top-50 start-50 border px-2 translate-middle"
       style="width: 360px"
-      th:if="${notice}"
+      th:if="${success}"
     >
       <div class="py-2 d-flex border-bottom align-items-center">
         <div class="bg-primary me-2" style="width: 1rem; height: 1rem"></div>
@@ -221,7 +221,22 @@
         <button id="toast-close" type="button" class="btn-close"></button>
       </div>
       <div class="py-2">
-        <span th:text="${notice}"></span>
+        <span th:text="${success}"></span>
+      </div>
+    </div>
+    <div
+      id="toast"
+      class="position-absolute bg-white shadow-lg top-50 start-50 border px-2 translate-middle"
+      style="width: 360px"
+      th:if="${failure}"
+    >
+      <div class="py-2 d-flex border-bottom align-items-center">
+        <div class="bg-danger me-2" style="width: 1rem; height: 1rem"></div>
+        <strong class="flex-grow-1">Information</strong>
+        <button id="toast-close" type="button" class="btn-close"></button>
+      </div>
+      <div class="py-2">
+        <span th:text="${failure}"></span>
       </div>
     </div>
     <!-- Scripts -->

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
     tty: true
     volumes:
       - ./api:/workspace
+      - ./api/img:/img
     depends_on:
       - db
 volumes:


### PR DESCRIPTION
・プロフィール編集処理の実装
・プロフィール編集時、トランザクションエラーが発生するとDBとディレクトリ内の画像ファイルの不整合が発生する。回避策として、画像を一時ディレクトリへ退避させておき、トランザクションエラー発生時には一時ディレクトリから呼び戻し、成功時には一時ディレクトリ内のファイルを削除するようにした